### PR TITLE
Access-Control-Allow-Origin for static

### DIFF
--- a/lib/impress.files.js
+++ b/lib/impress.files.js
@@ -175,6 +175,11 @@ Client.prototype.stream = function(filePath, stats) {
     client.res.setHeader('Accept-Ranges', 'bytes');
     stream = api.fs.createReadStream(filePath, { start: start, end: end });
   } else {
+    var allowOrigin = impress.getByPath(application.config, 'application.allowOrigin');
+    if (allowOrigin) {
+      client.res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+      client.res.setHeader('Access-Control-Allow-Headers', 'origin, content-type, accept');
+    }
     client.res.setHeader('Content-Length', stats.size);
     client.res.setHeader('Last-Modified', stats.mtime.toGMTString());
     stream = api.fs.createReadStream(filePath);


### PR DESCRIPTION
Fixing problem with getting fonts from subdomain, used for CDN, for example.