### PR TITLE
Add static pre-gzipped files support

### DIFF
--- a/lib/impress.client.js
+++ b/lib/impress.client.js
@@ -815,40 +815,71 @@ Client.prototype.runScript = function(handler, fileName, callback) {
 //
 Client.prototype.static = function(callback) {
   var client = this,
-      application = client.application;
+      application = client.application,
+      suffix = '.gz';
 
   var filePath = api.impress.stripTrailingSlash(application.dir + '/static' + client.path);
   if (client.path === '/') filePath = filePath + '/index.html';
   var relPath = application.relative(filePath),
       buffer = application.cache.static[relPath];
+
   if (buffer) {
     if (typeof(buffer) !== 'number') client.buffer(buffer);
     else callback();
-  } else api.fs.stat(filePath, function(err, stats) {
+  } else api.fs.stat(filePath + suffix, function(err, stats) {
     if (err) {
-      application.cache.static[relPath] = impress.FILE_NOT_FOUND;
-      application.watchCache(api.path.dirname(relPath));
-      callback();
-    } else {
-      if (stats.isDirectory()) {
-        var fileIndex = filePath + '/index.html',
-            relIndex = application.relative(fileIndex);
+      api.fs.stat(filePath, function(err, stats) {
+        if (err) {
+          application.cache.static[relPath] = impress.FILE_NOT_FOUND;
+          application.watchCache(api.path.dirname(relPath));
+          callback();
+        } else {
+          if (stats.isDirectory()) {
+            var fileIndex = filePath + '/index.html',
+                relIndex = application.relative(fileIndex);
 
-        buffer = application.cache.static[relIndex];
-        if (buffer) {
-          if (typeof(buffer) !== 'number') client.buffer(buffer);
-          else if (client.path === '/') callback();
-          else client.index(filePath);
-        } else api.fs.stat(fileIndex, function(err, stats) {
-          if (err) {
-            application.cache.static[relIndex] = impress.FILE_NOT_FOUND;
-            application.watchCache(api.path.dirname(relIndex));
-            if (client.path === '/') callback();
-            else client.index(filePath);
-          } else client.compress(fileIndex, stats);
-        });
-      } else if (stats.size < application.config.files.cacheMaxFileSize) client.compress(filePath, stats);
-      else client.stream(filePath, stats);
+            buffer = application.cache.static[relIndex];
+            if (buffer) {
+              if (typeof(buffer) !== 'number') client.buffer(buffer);
+              else if (client.path === '/') callback();
+              else client.index(filePath);
+            } else api.fs.stat(fileIndex + suffix, function(err, stats) {
+              if (err) {
+                api.fs.stat(fileIndex, function(err, stats) {
+                  if (err) {
+                    application.cache.static[relIndex] = impress.FILE_NOT_FOUND;
+                    application.watchCache(api.path.dirname(relIndex));
+                    if (client.path === '/') callback();
+                    else client.index(filePath);
+                  } else client.compress(fileIndex, stats);
+                });
+              } else {
+                api.fs.readFile(fileIndex + suffix, function(err, data) {
+                  if (err) client.error(404);
+                  else {
+                    client.stats = stats;
+                    client.compressed = true;
+                    client.end(data);
+                    application.addToCache(relIndex, stats, true, data)
+                  }
+                });
+              }
+            });
+          } else if (stats.size < application.config.files.cacheMaxFileSize)
+            client.compress(filePath, stats);
+          else client.stream(filePath, stats);
+        }
+      });
+    } else {
+      api.fs.readFile(filePath + suffix, function(err, data) {
+        if (err) client.error(404);
+        else {
+          client.stats = stats;
+          client.compressed = true;
+          client.end(data);
+          application.addToCache(relPath, stats, true, data)
+        }
+      });
     }
   });
 };


### PR DESCRIPTION
Relates to #465 

Implemented support for pre-gzipped files. Now static method tries to find compressed file first (with `.gz` extension). If it fails it fallbacks to previous behavior, and if it finds gzipped file, then it serves file and adds to cache.

@tshemsedinov please review if all is ok. I've run some test and all seems good. 
Also maybe it will be better to make some function like `serveAndCache` for code block:
```
api.fs.readFile(filePath + suffix, function(err, data) {
        if (err) client.error(404);
        else {
          client.stats = stats;
          client.compressed = true;
          client.end(data);
          application.addToCache(relPath, stats, true, data)
        }
      });
```
Or may be there is one, but I didn't find it.