### PR TITLE
Fix bug in API serving #468

### DIFF
--- a/lib/impress.client.js
+++ b/lib/impress.client.js
@@ -858,7 +858,7 @@ Client.prototype.serveStatic = function(relPath, onNotServed) {
       if (err) {
         application.cache.static[client.relPath] = impress.FILE_NOT_FOUND;
         application.watchCache(api.path.dirname(relPath));
-        if (client.path === '/') onNotServed();
+        if (client.path === '/' || !/^\/static\/[\w\/]+index\.html/.test(relPath)) onNotServed();
         else client.index(api.path.dirname(filePath));
       } else {
         if (stats.isDirectory()) {

--- a/lib/impress.client.js
+++ b/lib/impress.client.js
@@ -852,9 +852,12 @@ Client.prototype.serveStatic = function(relPath, onNotServed) {
   var client = this,
       application = client.application;
 
-  var gz = '.gz', filePath = application.dir + relPath;
+  var filePath = application.dir + relPath,
+      ext = api.impress.fileExt(relPath),
+      gz = api.impress.inArray(impress.COMPRESSED_EXT, ext) ? '' : '.gz';
+
   api.fs.stat(filePath + gz, function(err, stats) {
-    if (err) api.fs.stat(filePath, function(err, stats) {
+    if (err && gz) api.fs.stat(filePath, function(err, stats) {
       if (err) {
         application.cache.static[client.relPath] = impress.FILE_NOT_FOUND;
         application.watchCache(api.path.dirname(relPath));
@@ -867,7 +870,8 @@ Client.prototype.serveStatic = function(relPath, onNotServed) {
           client.compress(filePath, stats);
         } else client.stream(filePath, stats);
       }
-    }); else client.staticFile(filePath + gz, relPath + gz, stats);
+    }); else if (gz) client.staticFile(filePath + gz, relPath + gz, stats);
+    else client.stream(filePath, stats);
   });
 };
 


### PR DESCRIPTION
If `relPath` is not from static, then it should call callback function `onNotServed` to be able to proceed to server code, instead of trying to create index directory for it as it was done before adding static gz support.

This should fix #468.