### PR TITLE
Fix #467 Do not serve gz for compressed files

### DIFF
--- a/lib/impress.client.js
+++ b/lib/impress.client.js
@@ -852,9 +852,12 @@ Client.prototype.serveStatic = function(relPath, onNotServed) {
   var client = this,
       application = client.application;
 
-  var gz = '.gz', filePath = application.dir + relPath;
+  var filePath = application.dir + relPath,
+      ext = api.impress.fileExt(relPath),
+      gz = api.impress.inArray(impress.COMPRESSED_EXT, ext) ? '' : '.gz';
+
   api.fs.stat(filePath + gz, function(err, stats) {
-    if (err) api.fs.stat(filePath, function(err, stats) {
+    if (err && gz) api.fs.stat(filePath, function(err, stats) {
       if (err) {
         application.cache.static[client.relPath] = impress.FILE_NOT_FOUND;
         application.watchCache(api.path.dirname(relPath));
@@ -867,7 +870,8 @@ Client.prototype.serveStatic = function(relPath, onNotServed) {
           client.compress(filePath, stats);
         } else client.stream(filePath, stats);
       }
-    }); else client.staticFile(filePath + gz, relPath + gz, stats);
+    }); else if (gz) client.staticFile(filePath + gz, relPath + gz, stats);
+    else client.stream(filePath, stats);
   });
 };
 


### PR DESCRIPTION
Possible solution for #467. It obviously can be made with big if statement above first `api.fs.stat` function call or creating one more function for streaming already compressed files, but I think this way little bit tricky, but it has less lines of code :).

So @tshemsedinov feel free to change it according to your guidelines. 