### PR TITLE
Fix api.impress.each incorrect behaviour with empty arrays

### DIFF
--- a/lib/api.impress.js
+++ b/lib/api.impress.js
@@ -729,7 +729,8 @@ api.impress.each = function(items, iterator, done) {
       len = items.length,
       finished = false;
   done = api.impress.safeFunc(done);
-  items.forEach(function(item) {
+  if (len === 0) done();
+  else items.forEach(function(item) {
     iterator(item, function(result) {
       if (result instanceof Error) {
         if (!finished) done(result);


### PR DESCRIPTION
`api.impress.each` didn't invoke the callback when it was called on an empty array. This caused subsequent bugs in different places of Impress. For example, if an application used a MongoDB database which had no collections yet, Impress didn't load the application's libraries and init scripts.